### PR TITLE
Hack to play nice with iOSSnapshotTestCase too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
-### 3.x (Next)
+### 4.x (Next)
 
+* Updated to work with iOSSnapshotTestCase 5.x [@dbgrandi](https://github.com/dbgrandi)
 
 ### 3.1.1 (02/25/2017)
 

--- a/EXPMatchers+FBSnapshotTest.m
+++ b/EXPMatchers+FBSnapshotTest.m
@@ -24,6 +24,7 @@
     FBSnapshotTestController *snapshotController = [[FBSnapshotTestController alloc] initWithTestClass:[testCase class]];
     snapshotController.recordMode = record;
     snapshotController.referenceImagesDirectory = referenceDirectory;
+    snapshotController.imageDiffDirectory = NSProcessInfo.processInfo.environment[@"IMAGE_DIFF_DIR"];
     snapshotController.usesDrawViewHierarchyInRect = [Expecta usesDrawViewHierarchyInRect];
     snapshotController.deviceAgnostic = [Expecta isDeviceAgnostic];
   

--- a/EXPMatchers+FBSnapshotTest.m
+++ b/EXPMatchers+FBSnapshotTest.m
@@ -35,7 +35,7 @@
     return [snapshotController compareSnapshotOfViewOrLayer:viewOrLayer
                                                    selector:NSSelectorFromString(snapshot)
                                                  identifier:nil
-                                                  tolerance:tolerance
+                                           overallTolerance:tolerance
                                                       error:error];
 }
 

--- a/Expecta+Snapshots.podspec
+++ b/Expecta+Snapshots.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Expecta+Snapshots'
-  s.version      = '3.1.1'
+  s.version      = '4.0.0'
   s.summary      = 'Expecta matchers for taking view snapshots with FBSnapshotTestCase.'
   s.description  = "Use ios-snapshot-test-case's FBSnapshotTest with Expecta matchers for readability."
   s.homepage     = 'https://github.com/dblock/ios-snapshot-test-case-expecta'
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = '*.{h,m}'
   s.frameworks   = 'Foundation', 'XCTest'
-  s.dependency     'FBSnapshotTestCase/Core', '~> 2.0'
+  s.dependency     'iOSSnapshotTestCase/Core', '~> 5.0'
   s.dependency     'Expecta', '~> 1.0'
   s.dependency     'Specta', '~> 1.0'
   


### PR DESCRIPTION
When we have both Expecta+Snapshots (depends on FBSnapshotTestCase) and Nimble-Snapshots (depends on iOSSnapshotTestCase), I've noticed that failed snapshots do not get written to the `IMAGE_DIFF_DIR` directory anymore.

I'm throwing this in a fork as a migration plan for us to just move all of our snapshot based specs to Swift with Nimble.